### PR TITLE
HIVE-27845:Upgrade protobuf to 3.24.4 to fix CVEs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -193,7 +193,7 @@
     <parquet.version>1.13.1</parquet.version>
     <pig.version>0.16.0</pig.version>
     <plexus.version>1.5.6</plexus.version>
-    <protobuf.version>3.21.7</protobuf.version>
+    <protobuf.version>3.24.4</protobuf.version>
     <stax.version>1.0.1</stax.version>
     <slf4j.version>1.7.30</slf4j.version>
     <ST4.version>4.0.4</ST4.version>


### PR DESCRIPTION
What changes were proposed in this pull request?
In order to resolve the CVE fixes caused by old protobuf-java version, we are trying to upgrade it to 3.24.4 version.

Why are the changes needed?
We need to update the protobuf-java version in hive's pom.xml.

Does this PR introduce any user-facing change?
No

Is the change a dependency upgrade?
No

How was this patch tested?
Manual tests.
After updating the protobuf-java version, we build the hive project again.
After manually tested some DDL and SQL commands, hive is working as expected.